### PR TITLE
Remove misplaced 'https' on apiSignature.md example

### DIFF
--- a/docs/Pay/apiSignature.md
+++ b/docs/Pay/apiSignature.md
@@ -48,7 +48,7 @@ const headers = {
   'api-expires': expires
 };
 
-const url = `https://{{ PAY_API_URL }}${path}`;
+const url = `{{ PAY_API_URL }}${path}`;
 
 axios.get(url, { headers })
   .then(response => {


### PR DESCRIPTION
### Summary

Remove misplaced '`https`' on apiSignature.md example